### PR TITLE
[ETFE-beta2live-majorrel] Bump to 1.0.0 as demarcation from beta to live

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / scalaVersion := "2.13.12"
 lazy val microservice = Project("emcs-tfe-nrs-message-broker", file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .settings(
-    majorVersion        := 0,
+    majorVersion        := 1,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     // https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html
     // suppress warnings in generated routes files


### PR DESCRIPTION
symbolic more than anything, but provides a line-in-the-sand to track changes post moving from 'beta' to 'live'